### PR TITLE
Make 'find' tool act like 'dir' when no block is given

### DIFF
--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -61,7 +61,7 @@ module Maid::Tools
   #     # ...
   #   end
   def find(path, &block)
-    Find.find(File.expand_path(path), &block)
+    block.nil? ? dir(path) : Find.find(File.expand_path(path), &block)
   end
 
   # [Mac OS X] Use Spotlight to locate all files matching the given filename.

--- a/spec/lib/maid/tools_spec.rb
+++ b/spec/lib/maid/tools_spec.rb
@@ -71,6 +71,11 @@ module Maid
         Find.should_receive(:find).with("#@home/Downloads/foo.zip", &f)
         @maid.find('~/Downloads/foo.zip', &f)
       end
+
+      it 'should return an array when no block is given' do
+        Dir.should_receive(:[]).with("#@home/Downloads/foo.zip")
+        @maid.find('~/Downloads/foo.zip')
+      end
     end
 
     describe '#locate' do


### PR DESCRIPTION
Return an array when use `Maid::Tools#find` with no block.

Fix #27.
