### PR TITLE
`find` tool should return an array when no block is given

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
   specs:
     ZenTest (4.4.2)
     diff-lcs (1.1.2)
+    fakefs (0.4.0)
     rake (0.8.7)
     rspec (2.5.0)
       rspec-core (~> 2.5.0)
@@ -26,6 +27,7 @@ PLATFORMS
 
 DEPENDENCIES
   ZenTest (~> 4.4.2)
+  fakefs (~> 0.4.0)
   maid!
   rake (~> 0.8.7)
   rspec (~> 2.5.0)

--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -93,13 +93,24 @@ module Maid::Tools
 
   # Find matching files, akin to the Unix utility <tt>find</tt>.
   #
-  # Delegates to Find.find.
+  # If no block is given, it will return an array.
+  #
+  #   find '~/Downloads/'
+  #
+  # or delegates to Find.find.
   #
   #   find '~/Downloads/' do |path|
   #     # ...
   #   end
+  #
   def find(path, &block)
-    Find.find(File.expand_path(path), &block)
+    if block.nil?
+      files = []
+      Find.find(File.expand_path(path)) { |file_path| files << file_path }
+      files
+    else
+      Find.find(File.expand_path(path), &block)
+    end
   end
 
   # [Mac OS X] Use Spotlight to locate all files matching the given filename.

--- a/maid.gemspec
+++ b/maid.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 2.5.0')
   s.add_development_dependency('timecop', '~> 0.3.5')
   s.add_development_dependency('ZenTest', '~> 4.4.2')
+  s.add_development_dependency('fakefs', '~> 0.4.0')
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/spec/lib/maid/tools_spec.rb
+++ b/spec/lib/maid/tools_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Maid
-  describe Tools do
+  describe Tools, :fakefs => true do
     before :each do
       @home = File.expand_path('~')
       FileUtils.stub!(:mv)
@@ -17,6 +17,9 @@ module Maid
 
       # For safety, stub `cmd` to prevent running commands:
       @maid.stub(:cmd)
+
+      # mkdir on fakefs
+      FileUtils.mkdir_p("Foo/Bar")
     end
 
     describe '#move' do
@@ -128,6 +131,12 @@ module Maid
         f = lambda { }
         Find.should_receive(:find).with("#@home/Downloads/foo.zip", &f)
         @maid.find('~/Downloads/foo.zip', &f)
+      end
+
+      it "should return an an array of all the files's names when no block given" do
+        File.open("Foo/Bar/baz.txt", "w") { |f| f.puts("Ruby Rocks!") }
+        dir_path = File.expand_path("Foo/Bar")
+        @maid.find(dir_path).should == [dir_path, dir_path + '/baz.txt']
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,11 @@
 require 'rubygems'
 require 'rspec'
 require 'timecop'
+require 'fakefs/spec_helpers'
 
 require 'maid'
 
 Rspec.configure do |c|
   c.mock_with :rspec
+  c.include FakeFS::SpecHelpers, :fakefs => true
 end


### PR DESCRIPTION
- A default block is used to collect files' names when no block
  is given, and the array is returned as the result.
- Use fakefs for test.

As discussed at #33, I re-write the `find` method when no block is given.

Plz check it out, :)
