### PR TITLE
when running maid clean would complain about log_device attribute

### DIFF
--- a/lib/maid/maid.rb
+++ b/lib/maid/maid.rb
@@ -11,7 +11,7 @@ class Maid::Maid
     :file_options => {:noop => false}, # for FileUtils
   }.freeze
 
-  attr_reader :file_options, :logger, :rules, :rules_path, :trash_path
+  attr_reader :file_options, :logger, :log_device, :rules, :rules_path, :trash_path
   include ::Maid::Tools
 
   # Make a new Maid, setting up paths for the log and trash.


### PR DESCRIPTION
I noticed this error while running maid clean using the simple-tools branch.  I don't know if there is an easy way to test this without setting up an environment..
