### PR TITLE
Provide Vagrant config.vm.box_url for automatic downloading of a base box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,7 @@
 Vagrant::Config.run do |config|
   # See also: `script/vagrant-test`, `script/vagrant-test-all`
   config.vm.box = ENV['MAID_TARGET_BOX'] || 'precise64'
+  config.vm.box_url = 'http://files.vagrantup.com/precise64.box' if 'precise64' == config.vm.box
 
   config.vm.provision(:shell, :path => 'script/vagrant-provision', :args => ENV['MAID_TARGET_RUBY'] || '1.9.3')
 end


### PR DESCRIPTION
If someone tries to fire up the Vagrant VM to do testing, they'll get an error message if they lack a base box named `precise64`.

The Vagrantfile should provide a `config.vm.box_url` for automatic download of the base box, provided that the user hasn't overridden with `MAID_TARGET_BOX`.
