### PR TITLE
Added content_types method to pull from spotlight metadata

### DIFF
--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -404,9 +404,54 @@ module Maid::Tools
   #
   # ## Examples
   #
-  #     content_types('foo.zip') # => ['public.zip-archive', 'public.archive']
-  def content_types(path)
+  #     spotlight_content_types('foo.zip') # => ['public.zip-archive', 'public.archive']
+  def spotlight_content_types(path)
     mdls_to_array(path, 'kMDItemContentTypeTree')
+  end
+
+  # Get the content_types of a path
+  #
+  # Content types can be MIME types, internet media types or spotlight content types (OS X only)
+  #
+  # ## Examples
+  #
+  #     content_types('foo.zip') # => ["public.zip-archive", "com.pkware.zip-archive", "public.archive", "application/zip", "application"]
+  #     content_types('bar.jpg') # => ["public.jpeg", "public.image", "image/jpeg", "image"]
+  def content_types(path)
+    spotlight_content_types(path) << mime_type(path) << media_type(path)
+  end
+
+  # Get the MIME type of the file
+  #
+  # ## Examples
+  #
+  #     mime_type('bar.jpg') # => "image/jpeg"
+  def mime_type(path)
+    cmd("file -b --mime-type #{ path }").strip
+  end
+
+  # Get the iternet media type of the file
+  #
+  # The first part of the MIME type
+  #
+  # ## Examples
+  #
+  #     media_type('bar.jpg') # => "image"
+  def media_type(path)
+    mime_type(path).split('/').first
+  end
+
+  # Filter a directory by content_types
+  #
+  # Content types can be MIME types, internet media types or spotlight content types (OS X only)
+  #
+  # ## Examples
+  #
+  #     filter_by_content_type(dir('~/Downloads/*'), ['image', 'audio'])
+  #     filter_by_content_type(dir('~/Downloads/*'), public.image)
+  def filter_by_content_type(paths, filter_types)
+    filter_types = filter_types.is_a?(Array) ? filter_types : [filter_types] 
+    paths.select { |p| !(filter_types & content_types(p)).empty? }
   end
 
   private
@@ -428,8 +473,13 @@ module Maid::Tools
   end
 
   def mdls_to_array(path, attribute)
-    raw = cmd("mdls -raw -name #{attribute} #{ path.inspect }")
+    return [] unless os_x?
+    raw = cmd("mdls -raw -name #{attribute} #{ path }")
     clean = raw[1, raw.length - 2]
     clean.split(/,\s+/).map { |s| t = s.strip; t[1, t.length - 2] }
+  end
+
+  def os_x?
+    !cmd("which mdls").empty?
   end
 end


### PR DESCRIPTION
Using the kMDItemContentTypeTree spotlight metadata key, the content_types method gets an array of content types. These range from general to specific and allows for targeting general file groups like image, audio, archives, etc.

The "Organize Downloads" rule in my maid rules file shows how I use this. It's over here: [https://github.com/JohnColvin/.maid/blob/master/rules.rb](https://github.com/JohnColvin/.maid/blob/master/rules.rb)

Example image content_types array:
`["public.jpeg", "public.image", "public.data", "public.item", "public.content"]`

It uses the same cleaning as the raw output in `downloaded_from`. So, I extracted that code into a private method called `mdls_to_array`.
