### PR TITLE
Added filter_by_content_type

### DIFF
--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -427,7 +427,7 @@ module Maid::Tools
   #
   #     mime_type('bar.jpg') # => "image/jpeg"
   def mime_type(path)
-    cmd("file -b --mime-type #{ path }").strip
+    cmd("file -b --mime-type #{ path.inspect }").strip
   end
 
   # Get the iternet media type of the file
@@ -474,7 +474,7 @@ module Maid::Tools
 
   def mdls_to_array(path, attribute)
     return [] unless Maid::Platform.osx?
-    raw = cmd("mdls -raw -name #{attribute} #{ path }")
+    raw = cmd("mdls -raw -name #{attribute} #{ path.inspect }")
     return [] if raw.empty?
     clean = raw[1, raw.length - 2]
     clean.split(/,\s+/).map { |s| t = s.strip; t[1, t.length - 2] }


### PR DESCRIPTION
Based on the discussions at https://github.com/benjaminoakes/maid/pull/88 and https://github.com/benjaminoakes/maid/issues/51. I've added methods to retrieve spotlight content types, MIME types and interner media types.

These are used in the filter_by_content_type method. An example of this can be seen in my [maid rules file](https://github.com/JohnColvin/.maid/blob/master/rules.rb).

It also allows for multiple types in the filter. Like so:

```
images_and_audio = filter_by_content_type(dir('~/Downloads/*'), ['public.image', 'audio'])
```

This allows for easy moving of matched files:

```
move(filter_by_content_type(dir('~/Downloads/*'), 'image'), '~/Pictures/')
```
