### PR TITLE
add locate support for Ubuntu

### DIFF
--- a/lib/maid/platform.rb
+++ b/lib/maid/platform.rb
@@ -13,5 +13,16 @@ module Maid::Platform
     def osx?
       !!(host_os =~ /darwin/i)
     end
+
+  end
+
+  # Commands based on OS type
+  class Commands
+    class << self
+      # logicaly decides which locate command to use
+      def os_platform_locate
+        Maid::Platform.linux? ? "locate" : "mdfind -name"
+      end
+    end
   end
 end

--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -244,7 +244,7 @@ module Maid::Tools
   #
   #     locate('foo.zip') # => ['/a/foo.zip', '/b/foo.zip']
   def locate(name)
-    cmd("mdfind -name #{ sh_escape(name) }").split("\n")
+    cmd("#{Maid::Platform::Commands.os_platform_locate} #{ sh_escape(name) }").split("\n")
   end
 
   # [Mac OS X] Use Spotlight metadata to determine the site from which a file was downloaded.


### PR DESCRIPTION
I put something together after your response.  I sub-classed Platform::Commands for OS specific commands.  I do not know how you feel about this approach, but I feel it is more reusable down the road when more features are added.

Take care.  
