### PR TITLE
Add spec for showing version

### DIFF
--- a/spec/lib/maid/app_spec.rb
+++ b/spec/lib/maid/app_spec.rb
@@ -77,7 +77,7 @@ module Maid
     end
 
     it 'is mapped as --version' do
-      # TODO: Test via Rspec (it's only in the smoke test script for now)
+      App.start(['--version']).should == @app.version
     end
 
     context 'with the "long" option' do


### PR DESCRIPTION
Hi, I filled in a `TODO` in spec for displaying version with option `--version`. It's just one line I'm kinda new to this. I don't think it's either a feature or a bugfix so the change was made on the master branch. Please take a look.
