### PR TITLE
feature/require-option

### DIFF
--- a/lib/maid/app.rb
+++ b/lib/maid/app.rb
@@ -18,11 +18,6 @@ class Maid::App < Thor
   def clean
     maid = Maid::Maid.new(maid_options(options))
 
-    if Maid::TrashMigration.needed?
-      migrate_trash
-      return
-    end
-
     unless options.noop? || options.execute?
       say <<-EOF
 NOTE: Running 'maid clean' without option is deprecated. This behavior will be removed in v1.0.0.
@@ -35,12 +30,19 @@ maid clean --execute  # Run the rules at ~/.maid/rules.rb, logging to ~/.maid/ma
       return
     end
 
+    if Maid::TrashMigration.needed?
+      migrate_trash
+      return
+    end 
+
     unless options.silent? || options.noop?
       say "Logging actions to #{ maid.log_device.inspect }"
     end
 
-    maid.load_rules
-    maid.clean
+    if options.execute?
+      maid.load_rules
+      maid.clean
+    end
   end
 
   desc 'version', 'Print version information (optionally: system info)'

--- a/spec/lib/maid/app_spec.rb
+++ b/spec/lib/maid/app_spec.rb
@@ -43,10 +43,15 @@ module Maid
       @app.clean
     end
 
-    it 'should tell the Maid to clean' do      
+    it 'should clean when --execute is specified' do      
       @maid.should_receive(:clean)
       App.start(['clean', '--execute'])
     end 
+
+    it 'should not clean when --noop is specified' do
+      @maid.should_not_receive(:clean)
+      App.start(['clean', '--noop'])
+    end
 
     it 'should issue deprecation notice when called without option' do
       capture_stdout { App.start(['clean']) }.string.should match(/deprecated/)


### PR DESCRIPTION
These two commits contain test cases and corresponding implementation for [Issue #78](https://github.com/benjaminoakes/maid/issues/78). I created a new branch named `feature/require-option` in my repo. (maybe I should merge it back to `master` locally first?)

Basically the new code requires specifying either `--noop` or `--execute` when running `maid clean`, otherwise a deprecation message is displayed.

If either option is present, it displays output based on if `--silent` is specified.

Running `maid clean --silent` will result in displaying the deprecation message as well.

Mu
