### PR TITLE
copy iTunes files and remove duplicates

### DIFF
--- a/lib/maid/rules.sample.rb
+++ b/lib/maid/rules.sample.rb
@@ -76,8 +76,8 @@ Maid.rules do
   
   #Copy files, rather than move, from directory into iTunes.
     rule 'Move Downloaded Music to iTunes' do
-      FileUtils.cp_r('/Users/jesiegel2000/Movies/Torrents/Music/.', 
-      '/Users/jesiegel2000/Music/iTunes/iTunes Media/Automatically Add to iTunes/',
+      FileUtils.cp_r('/Users/.../Movies/.../Music/.', 
+      '/Users/.../Music/iTunes/iTunes Media/Automatically Add to iTunes/',
       :remove_destination => true)
   end
   

--- a/lib/maid/rules.sample.rb
+++ b/lib/maid/rules.sample.rb
@@ -72,6 +72,22 @@ Maid.rules do
     end
   end
   
+  require 'fileutils'
+  
+  #Copy files, rather than move, from directory into iTunes.
+    rule 'Move Downloaded Music to iTunes' do
+      FileUtils.cp_r('/Users/jesiegel2000/Movies/Torrents/Music/.', 
+      '/Users/jesiegel2000/Music/iTunes/iTunes Media/Automatically Add to iTunes/',
+      :remove_destination => true)
+  end
+  
+  #This will remove duplicates within iTunes due to above copy.
+  #This will NOT remove metadata from within iTunes.
+   rule 'Trash duplicate iTunes Songs' do
+      trash verbose_dupes_in('~/Music/iTunes/iTunes Media/Music/**/*')
+  end
+  
+  
   # NOTE: Currently, only Mac OS X supports `downloaded_from`.
   rule 'Old files downloaded while developing/testing' do
     dir('~/Downloads/*').each do |path|


### PR DESCRIPTION
This will NOT remove duplicate metadata from within iTunes.  Currently
working on a solution.