### PR TITLE
Pass option hash to Listen

### DIFF
--- a/lib/maid/maid.rb
+++ b/lib/maid/maid.rb
@@ -85,8 +85,8 @@ class Maid::Maid
     STDERR.puts e.message
   end
 
-  def watch(path, &rules)
-    @watches << ::Maid::Watch.new(self, path, &rules)
+  def watch(path, options = {}, &rules)
+    @watches << ::Maid::Watch.new(self, path, options, &rules)
   end
 
   def repeat(timestring, &rules)

--- a/lib/maid/watch.rb
+++ b/lib/maid/watch.rb
@@ -1,11 +1,12 @@
 require 'listen'
 class Maid::Watch
   include Maid::RuleContainer
-  
+
   attr_reader :path, :listener, :logger
-  
-  def initialize(maid, path, &rules)
+
+  def initialize(maid, path, options = {}, &rules)
     @maid = maid
+    @options = options
     @logger = maid.logger # TODO: Maybe it's better to create seperate loggers?
     @path = File.expand_path(path)
     initialize_rules(&rules)
@@ -13,17 +14,17 @@ class Maid::Watch
 
   def run
     unless rules.empty?
-      @listener = Listen.to(path) do |modified, added, removed|
+      @listener = Listen.to(path, @options) do |modified, added, removed|
         follow_rules(modified, added, removed)
       end
       @listener.start
     end
   end
-  
+
   def stop
     @listener.stop
   end
-  
+
   def join
     @listener.thread.join unless @listener.nil? || @listener.paused?
   end


### PR DESCRIPTION
I was using this myself, but forgot to make a pull request. This PR makes it possible to pass options to listen like this:

``` ruby
watch('~/Desktop', ignore: /some_directory/) do
  # rules in here
end
```
