### PR TITLE
`tree_empty?` and `ignore_child_dirs` tools

### DIFF
--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -740,6 +740,20 @@ module Maid::Tools
     }.length == 0
   end
 
+  # Given an array of directories, return a new array without any child
+  # directories whose parent is already present in that array.
+  #
+  # ## Example
+  #
+  #     ignore_child_dirs(["foo", "foo/a", "foo/b", "bar"]) # => ["foo", "bar"]
+  def ignore_child_dirs(arr)
+    arr.sort { |x, y|
+      y.count('/') - x.count('/')
+    }.select { |d|
+      not arr.include?(File.dirname(d))
+    }
+  end
+
   private
 
   def firefox_downloading?(path)

--- a/spec/lib/maid/tools_spec.rb
+++ b/spec/lib/maid/tools_spec.rb
@@ -725,5 +725,42 @@ module Maid
         expect(@maid.tree_empty?(@root)).to be(false)
       end
     end
+
+    describe '#ignore_child_dirs' do
+      it 'filters out any child directory' do
+        src = [
+          "a",
+          "b",
+          "b/x",
+          "c",
+          "c/x",
+          "c/y",
+          "d/x",
+          "d/y",
+          "e/x/y",
+          "e/x/y/z",
+          "f/x/y/z",
+          "g/x/y",
+          "g/x/z",
+          "g/y/a/b",
+          "g/y/a/c",
+        ]
+        expected = [
+          "a", # no child directories
+          "b", # ignore b/x
+          "c", # ignore c/x and c/y
+          "d/x", # no child directories
+          "d/y", # no child directories
+          "e/x/y", # ignore e/x/y/z
+          "f/x/y/z", # no empty parents
+          "g/x/y", # g/x isn't empty
+          "g/x/z",
+          "g/y/a/b", # g/y/a isn't empty
+          "g/y/a/c",
+        ].sort
+
+        expect(@maid.ignore_child_dirs(src).sort).to eq(expected)
+      end
+    end
   end
 end

--- a/spec/lib/maid/tools_spec.rb
+++ b/spec/lib/maid/tools_spec.rb
@@ -698,5 +698,32 @@ module Maid
         end
       end
     end
+
+    describe '#tree_empty?' do
+      before do
+        @root = '~/Source'
+        @empty_dir = (@parent_of_empty_dir = @root + '/empty-parent') + '/empty'
+        @file = (@non_empty_dir = @root + '/non-empty') + '/file.txt'
+        FileUtils.mkdir_p(@empty_dir)
+        FileUtils.mkdir_p(@non_empty_dir)
+        FileUtils.touch(@file)
+      end
+
+      it 'returns false for non-empty directories' do
+        expect(@maid.tree_empty?(@non_empty_dir)).to be(false)
+      end
+
+      it 'returns true for empty directories' do
+        expect(@maid.tree_empty?(@empty_dir)).to be(true)
+      end
+
+      it 'returns true for directories with empty subdirectories' do
+        expect(@maid.tree_empty?(@parent_of_empty_dir)).to be(true)
+      end
+
+      it 'returns false for directories with non-empty subdirectories' do
+        expect(@maid.tree_empty?(@root)).to be(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
Implement `tree_empty?` and `ignore_child_dirs` tools as commented in #144.