### PR TITLE
Finder Label Support

### DIFF
--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -9,6 +9,8 @@ require 'mime/types'
 require 'dimensions'
 require 'zip'
 
+require 'pathname'
+
 # These "tools" are methods available in the Maid DSL.
 #
 # In general, methods are expected to:
@@ -850,6 +852,22 @@ module Maid::Tools
     log "set tags #{ts} to #{path}"
     if !@file_options[:noop]
       `tag -s "#{ts}" "#{path}"`
+    end
+  end
+
+  # Tell if a file is hidden  
+  #
+  # ## Example
+  #
+  #     hidden?("~/.maid") # => true
+  def hidden?(path)
+    if Maid::Platform.osx? 
+      attribute = 'kMDItemFSInvisible'
+      raw = cmd("mdls -raw -name #{attribute} #{ sh_escape(path) }")
+      return raw == '1'
+    else
+      p = Pathname.new(expand(path))
+      return p.basename ~= /^\./
     end
   end
 

--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -360,7 +360,7 @@ module Maid::Tools
   #
   # See also: `dir_safe`
   def downloading?(path)
-    !!(chrome_downloading?(path) || firefox_downloading?(path) || safari_downloading?(path))
+    !!(chrome_downloading?(path) || firefox_downloading?(path) || safari_downloading?(path) || aria2_downloading?(path) || thunder_downloading?(path))
   end
 
   # Find all duplicate files in the given globs.
@@ -866,6 +866,14 @@ module Maid::Tools
 
   def safari_downloading?(path)
     path =~ /\.download$/
+  end
+
+  def aria2_downloading?(path)
+    File.exist?("#{path}.aria2") || path =~ /\.aria2$/
+  end
+
+  def thunder_downloading?(path)
+    path =~ /\.td$/ || path =~ /\.td.cfg$/
   end
 
   def has_tag_available?()

--- a/spec/lib/maid/tools_spec.rb
+++ b/spec/lib/maid/tools_spec.rb
@@ -771,5 +771,150 @@ module Maid
         expect(@maid.ignore_child_dirs(src).sort).to eq(expected)
       end
     end
+
+    describe '#tags' do
+      before do
+        @test_file = (@test_dir = '~/.maid/test/') + (@file_name = 'tag.zip')
+        `mkdir -p #{@test_dir}`
+        `touch #{@test_file}`
+        @maid.file_options[:noop] = false
+      end
+
+      after do
+        `rm -r #{@test_dir}`
+        @maid.file_options[:noop] = true
+      end
+
+      it 'get tags from a file that has one' do 
+        if system("which -s tag")
+          @maid.file_options[:noop] = false
+          @maid.add_tag(@test_file, "Test")
+          expect(@maid.tags(@test_file)).to eq(["Test"])
+        end
+      end
+
+      it 'get tags from a file that has serveral tags' do
+        if system("which -s tag")
+          @maid.file_options[:noop] = false
+          @maid.add_tag(@test_file, ["Test", "Twice"])
+          expect(@maid.tags(@test_file)).to eq(["Test", "Twice"])
+        end
+      end
+    end
+
+    describe '#has_tags?' do
+      before do
+        @test_file = (@test_dir = '~/.maid/test/') + (@file_name = 'tag.zip')
+        `mkdir -p #{@test_dir}`
+        `touch #{@test_file}`
+        @maid.file_options[:noop] = false
+      end
+
+      after do
+        `rm -r #{@test_dir}`
+        @maid.file_options[:noop] = true
+      end
+
+      it 'A file with tags' do 
+        if system("which -s tag")
+          @maid.add_tag(@test_file, "Test")
+          expect(@maid.has_tags?(@test_file)).to be(true)
+        end
+      end
+
+      it 'A file without tags' do
+          expect(@maid.has_tags?(@test_file)).to be(false)
+      end
+    end
+
+    describe '#contains_tag?' do
+      before do
+        @test_file = (@test_dir = '~/.maid/test/') + (@file_name = 'tag.zip')
+        `mkdir -p #{@test_dir}`
+        `touch #{@test_file}`
+        @maid.file_options[:noop] = false
+      end
+
+      after do
+        `rm -r #{@test_dir}`
+        @maid.file_options[:noop] = true
+      end
+
+      it 'A file with Test tag' do 
+        if system("which -s tag")
+          @maid.add_tag(@test_file, "Test")
+          expect(@maid.contains_tag?(@test_file, "Test")).to be(true)
+          expect(@maid.contains_tag?(@test_file, "Not there")).to be(false)
+        end
+      end
+    end
+
+    describe '#add_tag' do
+      before do
+        @test_file = (@test_dir = '~/.maid/test/') + (@file_name = 'tag.zip')
+        `mkdir -p #{@test_dir}`
+        `touch #{@test_file}`
+        @maid.file_options[:noop] = false
+      end
+
+      after do
+        `rm -r #{@test_dir}`
+        @maid.file_options[:noop] = true
+      end
+
+      it 'Add Test tag to a file' do 
+        if system("which -s tag")
+          @maid.add_tag(@test_file, "Test")
+          expect(@maid.contains_tag?(@test_file, "Test")).to be(true)
+        end
+      end
+    end
+
+    describe '#remove_tag' do
+      before do
+        @test_file = (@test_dir = '~/.maid/test/') + (@file_name = 'tag.zip')
+        `mkdir -p #{@test_dir}`
+        `touch #{@test_file}`
+        @maid.file_options[:noop] = false
+      end
+
+      after do
+        `rm -r #{@test_dir}`
+        @maid.file_options[:noop] = true
+      end
+
+      it 'Remove Test tag from a file' do 
+        if system("which -s tag")
+          @maid.add_tag(@test_file, "Test")
+          expect(@maid.contains_tag?(@test_file, "Test")).to be(true)
+          @maid.remove_tag(@test_file, "Test")
+          expect(@maid.contains_tag?(@test_file, "Test")).to be(false)
+        end
+      end
+    end
+
+    describe '#set_tag' do
+      before do
+        @test_file = (@test_dir = '~/.maid/test/') + (@file_name = 'tag.zip')
+        `mkdir -p #{@test_dir}`
+        `touch #{@test_file}`
+        @maid.file_options[:noop] = false
+      end
+
+      after do
+        `rm -r #{@test_dir}`
+        @maid.file_options[:noop] = true
+      end
+
+      it 'Set Test tags to a file' do 
+        if system("which -s tag")
+          @maid.set_tag(@test_file, "Test")
+          expect(@maid.contains_tag?(@test_file, "Test")).to be(true)
+          @maid.set_tag(@test_file, ["Test", "Twice"])
+          expect(@maid.contains_tag?(@test_file, "Test")).to be(true)
+          expect(@maid.contains_tag?(@test_file, "Twice")).to be(true)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Add Finder label support. Resolved benjaminoakes/maid#125

- `tags(path)` to get tags from a file
- `has_tags?(path)` to tell if a file has any tags
- `contains_tag?(path, tag)` to tell if a file has a certain tag
- `add_tag(path, tag)` to add a tag or a list of tags to a file
- `remove_tag(path, tag)` to remove a tag or a list of tags from a file
- `set_tag(path, tag)` to set a tag or a list of tags to a file