### PR TITLE
Try to Reduce Watch CPU Usage

### DIFF
--- a/lib/maid.rb
+++ b/lib/maid.rb
@@ -4,6 +4,7 @@ Deprecated.set_action(:warn)
 
 # Must be in this order:
 require 'maid/version'
+require 'maid/downloading'
 require 'maid/tools'
 require 'maid/rule_container'
 require 'maid/maid'

--- a/lib/maid/downloading.rb
+++ b/lib/maid/downloading.rb
@@ -1,0 +1,19 @@
+module Maid::Downloading
+  class << self
+    def downloading?(path)
+      !!(downloading_file_regexps.any? { |re| path.match(re) } || firefox_extra?(path) || aria2_extra?(path))
+    end
+
+    def downloading_file_regexps
+      [/\.crdownload$/, /\.download$/, /\.aria2$/, /\.td$/, /\.td.cfg$/, /\.part$/]
+    end
+
+    def firefox_extra?(path)
+      File.exist?("#{path}.part")
+    end
+
+    def aria2_extra?(path)
+      File.exist?("#{path}.aria2")
+    end
+  end
+end

--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -358,11 +358,12 @@ module Maid::Tools
     mdls_to_array(path, 'kMDItemWhereFroms')
   end
 
+  include Maid::Downloading
   # Detect whether the path is currently being downloaded in Chrome, Firefox or Safari.
   #
   # See also: `dir_safe`
   def downloading?(path)
-    !!(chrome_downloading?(path) || firefox_downloading?(path) || safari_downloading?(path) || aria2_downloading?(path) || thunder_downloading?(path))
+    Maid::Downloading.downloading?(path)
   end
 
   # Find all duplicate files in the given globs.
@@ -939,27 +940,6 @@ module Maid::Tools
   end
 
   private
-
-  def firefox_downloading?(path)
-    path =~ /\.part$/ ||
-      File.exist?("#{path}.part")
-  end
-
-  def chrome_downloading?(path)
-    path =~ /\.crdownload$/
-  end
-
-  def safari_downloading?(path)
-    path =~ /\.download$/
-  end
-
-  def aria2_downloading?(path)
-    File.exist?("#{path}.aria2") || path =~ /\.aria2$/
-  end
-
-  def thunder_downloading?(path)
-    path =~ /\.td$/ || path =~ /\.td.cfg$/
-  end
 
   def has_tag_available?()
     return Maid::Platform.osx? && system("which -s tag")

--- a/lib/maid/watch.rb
+++ b/lib/maid/watch.rb
@@ -1,6 +1,7 @@
 require 'listen'
 class Maid::Watch
   include Maid::RuleContainer
+  include Maid::Downloading
 
   attr_reader :path, :listener, :logger
 
@@ -9,7 +10,7 @@ class Maid::Watch
     if options.nil? 
       @lazy = true
       @options = { wait_for_delay: 10, 
-                   ignore: [/\.crdownload$/, /\.download$/, /\.aria2$/, /\.td$/, /\.td.cfg$/, /\.part$/] }
+                   ignore: Maid::Downloading.downloading_file_regexps }
     else
       @lazy = options.delete(:lazy) { |key| true }
       @options = options


### PR DESCRIPTION
This PR adds a `lazy mode` to `watch` and changes the default options hash that `watch` passes to `Listen`.

`Watch` will run in `lazy mode` by default. In this mode, `watch` only fires the following rules when there are added or removed files, ignoring modified files. The `lazy mode` behavior can be overridden by giving options with `{ lazy : false}`.

When there's no options given, `watch` will use the default options, which will check for changes every 10 seconds and ignore the downloading files.

This may resolve benjaminoakes/maid#149

I think this PR needs some code review and some discussion about how aggressively we want to reduce the CPU usage by default.