### PR TITLE
Fix OS X apps in zip files sample rule

### DIFF
--- a/lib/maid/rules.sample.rb
+++ b/lib/maid/rules.sample.rb
@@ -40,7 +40,7 @@ Maid.rules do
 
   rule 'Mac OS X applications in zip files' do
     found = dir('~/Downloads/*.zip').select { |path|
-      zipfile_contents(path).any? { |c| c.match(/\.app$/) }
+      zipfile_contents(path).any? { |c| c.match(/\.app\/Contents\//) }
     }
 
     trash(found)


### PR DESCRIPTION
Just started setting up Maid rules and noticed that the "OS X apps in zip files" rule doesn't work, even though there are plenty of such files in my Downloads folder.

The issue turned out to be that `zipfile_contents(path)` (at least in OS X Sierra) recursively iterates over paths inside `*.app` packages, so paths that the rule tests don't end with `.app` — instead it iterates over paths like `Last.fm.app/Contents/MacOS/Last.fm`. This change fixed the issue for me, although I'm not sure whether the rule was always broken or if it's a change of behavior in one of OS X updates.

Thanks for the awesome tool @benjaminoakes!