### PR TITLE
Fixed naming of Vagrant boxes.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,8 +3,7 @@
 
 Vagrant.configure('2') do |config|
   # See also: `script/vagrant-test`, `script/vagrant-test-all`
-  config.vm.box     = ENV['MAID_TARGET_BOX'] || 'precise64'
-  config.vm.box_url = 'http://files.vagrantup.com/precise64.box' if 'precise64' == config.vm.box
+  config.vm.box     = ENV['MAID_TARGET_BOX'] || 'hashicorp/precise64'
 
   config.vm.provider :virtualbox do |vb|
     # Maid has very low system requirements

--- a/script/vagrant-test-all
+++ b/script/vagrant-test-all
@@ -28,7 +28,7 @@
 # * [Vagrant Boxes List](http://www.vagrantbox.es/)
 # * [Contributing Guide](https://github.com/benjaminoakes/maid/wiki/Contributing)
 
-MAID_TARGET_BOX='precise32' MAID_TARGET_RUBY='1.9.3' script/vagrant-test
-MAID_TARGET_BOX='precise64' MAID_TARGET_RUBY='1.9.3' script/vagrant-test
+MAID_TARGET_BOX='hashicorp/precise32' MAID_TARGET_RUBY='1.9.3' script/vagrant-test
+MAID_TARGET_BOX='hashicorp/precise64' MAID_TARGET_RUBY='1.9.3' script/vagrant-test
 # TODO: Locate and add box for `saucy32`
 # TODO: Locate and add box for `saucy64`


### PR DESCRIPTION
`vagrant up` failed because it was not able to connect to https://hashicorp-files.hashicorp.com

This is due to a switch to Vagrant cloud. The boxes are now called differently.

cf.
https://github.com/hashicorp/vagrant/issues/9897#issuecomment-394945635