### PR TITLE
Fix geolookup.

### DIFF
--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -456,7 +456,7 @@ module Maid::Tools
       gps = EXIFR::JPEG.new(path).gps
       coordinates_string = [gps.latitude, gps.longitude]
       location = Geocoder.search(coordinates_string).first
-      [location.city, location.province, location.country_code].join(', ')
+      [location.city, location.province, location.country_code.upcase].join(', ')
     end
   end
 

--- a/maid.gemspec
+++ b/maid.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency('listen', '>= 2.8.0', '< 3.1.0')
   s.add_dependency('rufus-scheduler', '>= 3.0.6', '< 3.2.0')
   s.add_dependency('exifr', '~> 1.2.0')
-  s.add_dependency('geocoder', '~> 1.2.0')
+  s.add_dependency('geocoder', '~> 1.5.0')
   
   # TODO: use one of these two gems instead of `mdfind`.  **But** They have to work on Linux as well.
   #


### PR DESCRIPTION
Default provider for the geocoder gem has been google. Since version 1.5.0 geocoder changed its default provider to nominatim (OpenStreetMap's API). Google requires an API key. Whereas nominatim is free to use without an API key. Although it restricts usage to 1 request per second.

This solution probably makes the test pass, but might not work when a lot of images are classified. There's also the risk of being blocked.

I don't know of a free and rate-unlimited API. Probably the easiest solution would be to let users configure an API key in their local installations, if they want to use geocoding.