### PR TITLE
Upgrade Rake development dependency

### DIFF
--- a/maid.gemspec
+++ b/maid.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('fakefs', '~> 0.4.3')
   s.add_development_dependency('guard', '~> 2.12.5')
   s.add_development_dependency('guard-rspec', '~> 4.6.2')
-  s.add_development_dependency('rake', '~> 10.4.2')
+  s.add_development_dependency('rake', '>= 12.3.3')
   s.add_development_dependency('redcarpet', '~> 3.3.2') # Soft dependency of `yard`
   s.add_development_dependency('rspec', '~> 3.3.0')
   s.add_development_dependency('timecop', '~> 0.7.0')


### PR DESCRIPTION
CVE-2020-8130

Only used for development purposes.  Seems to require Rspec upgrades, etc too.